### PR TITLE
add an xs test

### DIFF
--- a/t/04_xs.t
+++ b/t/04_xs.t
@@ -1,0 +1,44 @@
+use Test::More;
+use Test::Alien;
+use Alien::PCRE2;
+
+alien_ok 'Alien::PCRE2';
+
+xs_ok do { local $/; <DATA> }, with_subtest {
+
+  my $re = Foo::pcre2_compile("pattern");
+  ok $re, "returned a non-null pointer";
+  note "re = $re";
+
+  Foo::pcre2_code_free($re);
+
+};
+
+done_testing;
+
+__DATA__
+ 
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+MODULE = Foo PACKAGE = Foo
+
+void *
+pcre2_compile(pattern)
+    const char *pattern
+  CODE:
+    pcre2_code *re;
+    int errornumber;
+    PCRE2_SIZE erroroffset;
+    RETVAL = pcre2_compile((PCRE2_SPTR)pattern, PCRE2_ZERO_TERMINATED, 0, &errornumber, &erroroffset, NULL);
+  OUTPUT:
+    RETVAL
+
+void
+pcre2_code_free(re)
+    void *re
+  CODE:
+    pcre2_code_free((pcre2_code *)re);


### PR DESCRIPTION
This tests your alien using Test::Alien, which builds a toy XS and then interrogates it to ensure that it works correctly.  In my experience it is much better than interrogating the filesystem or flags returned by the Alien itself, as the results may not be portable, or consistent between system and share build, and this tests the Alien in the way that it will actually be used.

I would suggest that it would be a good idea to write a similar test for Alien::JPCRE2, though a couple of things:

 1. I am not sure of the appropriate incantation in C++ / jprc2
 2. Test::Alien probably needs some enhancements to work with C++, but this could drive development of that feature.