### PR TITLE
Fix t/02_pcre2_config.t plan for system installation

### DIFF
--- a/t/02_pcre2_config.t
+++ b/t/02_pcre2_config.t
@@ -22,12 +22,15 @@ print {*STDERR} "\n\n", q{<<< DEBUG >>> in t/02_pcre2_config.t, have $pcre2_bin_
 unshift @PATH, @{ $pcre2_bin_dirs };
 
 # test pcre2 directory permissions
-foreach my $pcre2_bin_dir (@{$pcre2_bin_dirs}) {
-    ok(defined $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is defined');
-    isnt($pcre2_bin_dir, q{}, 'Alien::PCRE2->bin_dir() element is not empty');
-    ok(-e $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element exists');
-    ok(-r $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is readable');
-    ok(-d $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is a directory');
+SKIP: {
+    skip 'PCRE2 is system install type', 5 if Alien::PCRE2->install_type eq 'system';
+    foreach my $pcre2_bin_dir (@{$pcre2_bin_dirs}) {
+        ok(defined $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is defined');
+        isnt($pcre2_bin_dir, q{}, 'Alien::PCRE2->bin_dir() element is not empty');
+        ok(-e $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element exists');
+        ok(-r $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is readable');
+        ok(-d $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is a directory');
+    }
 }
 
 # check if `pcre2-config` can be run, if so get path to binary executable


### PR DESCRIPTION
If system PCRE2 is used, bin_dir() list is empty per Alien::Base
documentation. This caused a test failure due to bad test plan. This
patch fixes it.