### PR TITLE
Accept PCRE2 release candidates

### DIFF
--- a/t/02_pcre2_config.t
+++ b/t/02_pcre2_config.t
@@ -94,7 +94,7 @@ SKIP: {
     my $version_0 = $version->[0];
     print {*STDERR} "\n\n", q{<<< DEBUG >>> in t/02_pcre2_config.t, have $version_0 = '}, $version_0, q{'}, "\n\n";
     ok(defined $version_0, 'Command `pcre2-config --version` 1 line of output is defined');
-    ok($version_0 =~ m/^([\d\.]+)(?:-DEV)?$/xms, 'Command `pcre2-config --version` 1 line of output is valid');  # match both stable & dev versions
+    ok($version_0 =~ m/^([\d\.]+)(?:-(?:DEV|RC\d))?$/xms, 'Command `pcre2-config --version` 1 line of output is valid');  # match both stable & dev versions
 
     my $version_split = [split /[.]/, $1];
     print {*STDERR} "\n\n", q{<<< DEBUG >>> in t/02_pcre2_config.t, have $version_split = }, Dumper($version_split), "\n\n";

--- a/t/03_pcre2grep.t
+++ b/t/03_pcre2grep.t
@@ -20,7 +20,7 @@ print {*STDERR} "\n", q{<<< DEBUG >>> in t/03_pcre2grep.t, have $run_object->err
 $run_object->success('Command `pcre2grep --version` runs successfully');
 is((substr $run_object->out(), 0, 18), 'pcre2grep version ', 'Command `pcre2grep --version` output starts correctly');
 # DEV NOTE: can't use out_like() on the next line because it does not properly capture to $1, as used in the following split
-ok($run_object->out() =~ m/([\d\.]+)(?:-DEV)?[\d\.\-\s]*$/xms, 'Command `pcre2grep --version` runs with valid output');
+ok($run_object->out() =~ m/([\d\.]+)(?:-(?:DEV|RC\d))?[\d\.\-\s]*$/xms, 'Command `pcre2grep --version` runs with valid output');
 
 # test actual version numbers
 my $version_split = [split /[.]/, $1];


### PR DESCRIPTION
PCRE2 release candidate version string looks like "10.31-RC1". Some
tests failed because of the "-RC1" suffix.

This patch fixed them to accepts /-RC\d/ on the same places where
/-DEV/ is accepted.

Signed-off-by: Petr Písař <ppisar@redhat.com>