### PR TITLE
Update CI and fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # bash on macos and linux
+        # powershell on windows + strawberry perl
+        # msys2 {0} on windows + msys2
+        shell: >-
+          ${{   fromJSON( '["", "bash {0}"]'       )[ startsWith(matrix.os, 'ubuntu-' ) || startsWith(matrix.os, 'macos-') ]
+          }}${{ fromJSON( '["", "powershell {0}"]' )[ startsWith(matrix.os, 'windows-') && matrix.dist == 'strawberry'     ]
+          }}${{ fromJSON( '["", "msys2 {0}"]'      )[ startsWith(matrix.os, 'windows-') && matrix.dist == 'msys2'          ] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        perl-version: ['5.8', '5.20', '5.30', '5.34']
+        alien-install-type: [ 'system', 'share' ]
+        include:
+          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'  }
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'system' }
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'  }
+          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'system' }
+          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'share'  }
+    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }} with install-type ${{ matrix.alien-install-type }}, dist ${{ matrix.dist }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Setup system PCRE2
+      - name: Setup system PCRE2 (apt)
+        if: runner.os == 'Linux' && matrix.alien-install-type == 'system'
+        run: |
+          sudo apt-get -y update && sudo apt-get install -y libpcre2-dev
+      - name: Setup system PCRE2 (homebrew)
+        if: runner.os == 'macOS' && matrix.alien-install-type == 'system'
+        run: |
+          brew install pcre2
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows' && matrix.dist == 'msys2'
+        with:
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-perl
+      - name: Set up PCRE2 (MSYS2/MinGW pacman)
+        if: runner.os == 'Windows' && matrix.dist == 'msys2' && matrix.alien-install-type == 'system'
+        shell: msys2 {0}
+        run: |
+          pacman -S --needed --noconfirm mingw-w64-x86_64-pcre2
+
+      # Setup Perl
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          perl-version: ${{ matrix.perl-version }}
+      - name: Set up perl (Strawberry)
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os == 'windows-latest' && matrix.dist == 'strawberry'
+        with:
+          distribution: 'strawberry'
+
+      - run: perl -V
+      - name: Install cpanm
+        if: runner.os == 'Windows' && matrix.dist == 'msys2'
+        run:
+          yes | cpan -T App::cpanminus || true
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest Alien::Build::MM
+          cpanm --notest --installdeps .
+
+      - name: Set ALIEN_INSTALL_TYPE
+        shell: bash
+        run: |
+          echo "ALIEN_INSTALL_TYPE=${{ matrix.alien-install-type }}" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          cpanm --verbose --test-only .

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,6 @@ BEGIN {
 # MS Windows OS, fix read-only blib/lib directory & enable GNU configure/make
 my $configure_requires_windows = {};
 if ( $OSNAME eq 'MSWin32' ) {
-    push( @ExtUtils::MakeMaker::Overridable, qw(pm_to_blib) );
     $configure_requires_windows = {
         'Alien::MSYS'  => '0.08',
         'Alien::gmake' => '0.20',
@@ -68,24 +67,14 @@ WriteMakefile($abmm->mm_args(
     },
 ));
 
-
-package MY;
-BEGIN { use English; }
-
-sub postamble {
-    $abmm->mm_postamble;
-}
-
-sub pm_to_blib {
-    my $self = shift;
-    my $blib = $self->SUPER::pm_to_blib(@_);
-
-    # un-read-only blib/lib for tests to pass, files are modified at runtime there
-    if ( $OSNAME eq 'MSWin32' ) {
-        my ( $lastline, $start ) = qq{\t\$(NOECHO) \$(TOUCH) pm_to_blib\n};
-        ( $start = index( $blib, $lastline ) ) == -1
-            && die "Can't find replacement string for pm_to_blib target";
-        substr( $blib, $start, 0, "\t" . 'attrib -R /S  blib/lib/*' . "\n" );
-    }
-    return $blib;
+{ package
+    MY;
+  sub postamble {
+    $abmm->mm_postamble(@_);
+  }
+  sub install {
+    $abmm->can('mm_install')
+      ? $abmm->mm_install(@_)
+      : shift->SUPER::install(@_);
+  }
 }

--- a/alienfile
+++ b/alienfile
@@ -12,8 +12,7 @@ plugin 'PkgConfig' => (
  
 share {
     plugin Download => (
-#        url => 'ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/',  # ERROR: "Sorry, you may not have multiple connections."
-        url => 'https://wbraswell.github.io/pcre2-mirror/',  # GitHub mirror server
+        url => 'https://github.com/PhilipHazel/pcre2/releases',
 
         filter => qr/^pcre2-.*\.tar\.gz$/,
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,11 @@ skip_tags: true
 clone_depth: 1
 clone_folder: C:\projects\alien-pcre2
 
-#environment:
-#    matrix:
+environment:
+    matrix:
+        - BITS: 32
+        - BITS: 64
+
 # DEV NOTE, CORRELATION #ap011: hackish code, setting ALIEN_INSTALL_TYPE=share causes Alien::gmake to fail to properly install in system mode with pre-installed C:\strawberry\c\bin\gmake.exe
         # share test, compile PCRE2 from source
 #        - ALIEN_INSTALL_TYPE: share
@@ -19,12 +22,9 @@ clone_folder: C:\projects\alien-pcre2
 # DEV NOTE: Windows OS, force manual install w/out test of IO::Socket::SSL, about 50% of the time it hangs on the test after "t/sysread_write.t ................. ok"
 install:
 - cmd: >-
+    IF %BITS%==64 ( choco install strawberryperl )
 
-    choco install curl
-
-    curl -o perl.msi http://strawberryperl.com/download/5.26.0.1/strawberry-perl-5.26.0.1-32bit.msi
-
-    msiexec /i perl.msi /quiet /qn /norestart
+    IF %BITS%==32 ( choco install strawberryperl --x86 )
 
     set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;C:\windows\system32;C:\windows;%path%
 

--- a/t/01_use.t
+++ b/t/01_use.t
@@ -2,6 +2,12 @@ use strict;
 use warnings;
 our $VERSION = 0.001_000;
 
-use Test::More tests => 1;
+use Test2::V0;
+use Test::Alien;
+use Test::Alien::Diag;
+use Alien::PCRE2;
 
-use_ok('Alien::PCRE2');
+alien_diag 'Alien::PCRE2';
+alien_ok 'Alien::PCRE2';
+
+done_testing;

--- a/t/02_pcre2_config.t
+++ b/t/02_pcre2_config.t
@@ -12,23 +12,25 @@ use English qw(-no_match_vars);  # for $OSNAME
 use Capture::Tiny qw( capture_merged );
 use Data::Dumper;  # DEBUG
 
-plan(28);
+plan(24);
 
 # load alien
 alien_ok('Alien::PCRE2', 'Alien::PCRE2 loads successfully and conforms to Alien::Base specifications');
 
 my $pcre2_bin_dirs = [ Alien::PCRE2->bin_dir() ];
 print {*STDERR} "\n\n", q{<<< DEBUG >>> in t/02_pcre2_config.t, have $pcre2_bin_dirs = '}, Dumper($pcre2_bin_dirs), q{'}, "\n\n";
-unshift @PATH, @{ $pcre2_bin_dirs };
 
-# test pcre2 directory permissions
-foreach my $pcre2_bin_dir (@{$pcre2_bin_dirs}) {
-    ok(defined $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is defined');
-    isnt($pcre2_bin_dir, q{}, 'Alien::PCRE2->bin_dir() element is not empty');
-    ok(-e $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element exists');
-    ok(-r $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is readable');
-    ok(-d $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is a directory');
-}
+subtest 'Check bin_dir permissions' => sub {
+    skip_all 'No bin_dir for system install' if Alien::PCRE2->install_type('system');
+    # test pcre2 directory permissions
+    foreach my $pcre2_bin_dir (@{$pcre2_bin_dirs}) {
+        ok(defined $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is defined');
+        isnt($pcre2_bin_dir, q{}, 'Alien::PCRE2->bin_dir() element is not empty');
+        ok(-e $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element exists');
+        ok(-r $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is readable');
+        ok(-d $pcre2_bin_dir, 'Alien::PCRE2->bin_dir() element is a directory');
+    }
+};
 
 # check if `pcre2-config` can be run, if so get path to binary executable
 my $pcre2_path = undef;

--- a/t/03_pcre2grep.t
+++ b/t/03_pcre2grep.t
@@ -8,7 +8,11 @@ use Alien::PCRE2;
 use English qw(-no_match_vars);  # for $OSNAME
 use Data::Dumper;  # DEBUG
 
-plan(10);
+if( Alien::PCRE2->install_type('system') ) {
+    skip_all 'pcre2grep might not be installed for system install';
+} else {
+    plan(10);
+}
 
 # load alien
 alien_ok('Alien::PCRE2', 'Alien::PCRE2 loads successfully and conforms to Alien::Base specifications');


### PR DESCRIPTION
- Add initial GitHub Actions CI workflow
- Use Test::Alien for t/01_use.t
- Skip `t/03_pcre2grep.t` for system install
- Update URL for releases to GitHub. Fixes <https://github.com/wbraswell/alien-pcre2/issues/10>.
- Rewrite postamble
- Do not check bin_dir() if system install. No longer need <https://github.com/wbraswell/alien-pcre2/pull/7>, <https://github.com/wbraswell/alien-pcre2/pull/9>.
