### PR TITLE
Allow for env variable to set minimum version

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -7,7 +7,12 @@ plugin 'PkgConfig' => (
     pkg_name =>'libpcre2-8',
 #    pkg_name =>'libpcre2-16',
 #    pkg_name =>'libpcre2-32',
-    minimum_version => '10.40',
+    # NOTE Setting minimum_version to 10.34 due to
+    # <https://nvd.nist.gov/vuln/detail/CVE-2019-20454>.
+    minimum_version =>
+        exists $ENV{ALIEN_PCRE2_MIN_VERSION}
+        ? $ENV{ALIEN_PCRE2_MIN_VERSION}
+        : '10.34',
 );
  
 share {


### PR DESCRIPTION
And set the default `minimum_version` to 10.34 which is the first
version not affected by <https://nvd.nist.gov/vuln/detail/CVE-2019-20454>
